### PR TITLE
fixHeaders produces invalid headers array

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -70,7 +70,7 @@ class PostmarkClient extends PostmarkClientBase {
 			$retval = [];
 			$index = 0;
 			foreach ($headers as $key => $value) {
-				$retval[$index] = [$key => $value];
+				$retval[$index] = ['Name' => $key, 'Value' => $value];
 				$index++;
 			}
 		}


### PR DESCRIPTION
Fix `fixHeaders()` to produce valid headers array