### PR TITLE
Bump minimum required PHP version to >= 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license" : "MIT",
     "description": "The officially supported client for Postmark (http://postmarkapp.com)",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "guzzlehttp/guzzle": "5.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hello.

As you're using the [Array Dereferencing](https://github.com/wildbit/postmark-php/blob/master/.travis.yml#L4) feature added in PHP 5.4, and only testing PHP 5.4 via [Travis](https://github.com/wildbit/postmark-php/blob/master/composer.json#L6), I'm going to assume that the minimum requirement of >= 5.3 is invalid.

Thanks,