### PR TITLE
Added support for PHP 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license" : "MIT",
     "description": "The officially supported client for Postmark (http://postmarkapp.com)",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.0",
         "guzzlehttp/guzzle": "5.1.0"
     },
     "require-dev": {

--- a/src/Postmark/Models/CaseInsensitiveArray.php
+++ b/src/Postmark/Models/CaseInsensitiveArray.php
@@ -67,7 +67,8 @@ class CaseInsensitiveArray implements \ArrayAccess, \Iterator {
 	}
 
 	public function key() {
-		return array_keys($this->_container)[$this->_pointer];
+        $keys = array_keys($this->_container);
+		return $keys[$this->_pointer];
 	}
 
 	public function next() {

--- a/src/Postmark/Models/PostmarkAttachment.php
+++ b/src/Postmark/Models/PostmarkAttachment.php
@@ -23,12 +23,12 @@ class PostmarkAttachment implements \JsonSerializable {
 
 	function jsonSerialize() {
 
-		$retval = [
+		$retval = array(
 			"Name" => $this->name,
 			"Content" => $this->data,
 			"ContentType" => $this->mimeType ?: "application/octet-stream",
 			"ContentId" => $this->name,
-		];
+        );
 
 		return $retval;
 	}

--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -68,10 +68,10 @@ class PostmarkClient extends PostmarkClientBase {
 	private function fixHeaders($headers) {
 		$retval = NULL;
 		if ($headers != NULL) {
-			$retval = [];
+			$retval = array();
 			$index = 0;
 			foreach ($headers as $key => $value) {
-				$retval[$index] = ['Name' => $key, 'Value' => $value];
+				$retval[$index] = array('Name' => $key, 'Value' => $value);
 				$index++;
 			}
 		}
@@ -91,7 +91,7 @@ class PostmarkClient extends PostmarkClientBase {
 	 */
 	function sendEmailBatch($emailBatch = array()) {
 
-		$final = [];
+		$final = array();
 
 		foreach ($emailBatch as $key => $email) {
 			foreach ($email as $emailIdx => $emailValue) {

--- a/src/Postmark/PostmarkClientBase.php
+++ b/src/Postmark/PostmarkClientBase.php
@@ -49,18 +49,18 @@ abstract class PostmarkClientBase {
 	 */
 	protected function processRestRequest($method = NULL, $path = NULL, $body = NULL) {
 
-		$client = new \GuzzleHttp\Client(['defaults' => [
+		$client = new \GuzzleHttp\Client(array('defaults' => array(
 			'exceptions' => false,
 			'timeout' => $this->timeout,
-		],
-		]);
+        ),
+        ));
 
 		$url = PostmarkClientBase::$BASE_URL . $path;
 
-		$options = [];
+		$options = array();
 
 		if ($body != NULL) {
-			$cleanParams = [];
+			$cleanParams = array();
 
 			foreach ($body as $key => $value) {
 				if ($value !== NULL) {

--- a/tests/PostmarkAdminClientSenderSignatureTest.php
+++ b/tests/PostmarkAdminClientSenderSignatureTest.php
@@ -62,7 +62,8 @@ class PostmarkAdminClientSenderSignatureTest extends PostmarkClientBaseTest {
 		$i = $tk->WRITE_TEST_SENDER_SIGNATURE_PROTOTYPE;
 		$sender = str_replace('[token]', 'test-php-edit' . date('U'), $i);
 
-		$returnPath = 'test.' . explode('@', $tk->WRITE_TEST_SENDER_SIGNATURE_PROTOTYPE)[1];
+        $exploded = explode('@', $tk->WRITE_TEST_SENDER_SIGNATURE_PROTOTYPE);
+		$returnPath = 'test.' . $exploded[1];
 
 		$sig = $client->createSenderSignature($sender, $name, NULL, $returnPath);
 

--- a/tests/PostmarkClientEmailTest.php
+++ b/tests/PostmarkClientEmailTest.php
@@ -40,7 +40,7 @@ class PostmarkClientEmailTest extends PostmarkClientBaseTest {
 			'<b>Hi there!</b>',
 			'This is a text body for a test email.',
 			NULL, true, NULL, NULL, NULL,
-			["X-Test-Header" => "Header.", 'X-Test-Header-2' => 'Test Header 2'], [$attachment]);
+			array("X-Test-Header" => "Header.", 'X-Test-Header-2' => 'Test Header 2'), array($attachment));
 
 		$this->assertNotEmpty($response, 'The client could not send a message with an attachment.');
 	}
@@ -61,7 +61,7 @@ class PostmarkClientEmailTest extends PostmarkClientBaseTest {
 			'<b>Hi there! From <img src="cid:hello.png"/></b>',
 			'This is a text body for a test email.',
 			NULL, true, NULL, NULL, NULL,
-			["X-Test-Header" => "Header.", 'X-Test-Header-2' => 'Test Header 2'], [$attachment]);
+			array("X-Test-Header" => "Header.", 'X-Test-Header-2' => 'Test Header 2'), array($attachment));
 
 		$this->assertNotEmpty($response, 'The client could not send a message with an attachment.');
 	}
@@ -71,22 +71,22 @@ class PostmarkClientEmailTest extends PostmarkClientBaseTest {
 
 		$currentTime = date("c");
 
-		$batch = [];
+		$batch = array();
 
 		$attachment = PostmarkAttachment::fromRawData("attachment content",
 			"hello.txt", "text/plain");
 
 		for ($i = 0; $i < 5; $i++) {
-			$payload = [
+			$payload = array(
 				'From' => $tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
 				'To' => $tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
 				'Subject' => "Hello from the PHP Postmark Client Tests! ($currentTime)",
 				'HtmlBody' => '<b>Hi there! (batch test)</b>',
 				'TextBody' => 'This is a text body for a test email.',
 				'TrackOpens' => true,
-				'Headers' => ["X-Test-Header" => "Test Header Content", 'X-Test-Date-Sent' => date('c')],
-				'Attachments' => [$attachment],
-			];
+				'Headers' => array("X-Test-Header" => "Test Header Content", 'X-Test-Date-Sent' => date('c')),
+				'Attachments' => array($attachment),
+            );
 
 			$batch[] = $payload;
 		}

--- a/tests/TestingKeys.php
+++ b/tests/TestingKeys.php
@@ -16,7 +16,7 @@ class TestingKeys {
 	public $WRITE_TEST_SENDER_SIGNATURE_PROTOTYPE;
 
 	function __construct() {
-		$test_keys = [];
+		$test_keys = array();
 
 		$keyfile = __DIR__ . "/../test_keys.json";
 


### PR DESCRIPTION
Removed short array notation, making things compatible with PHP 5.3.

I couldn't seem to get the phpunit tests to work. I may not have my `test_keys.json` file setup correctly.