### PR TITLE
Allow injectable GuzzleHttp\Client for PostmarkClientBase.

### DIFF
--- a/src/Postmark/PostmarkClientBase.php
+++ b/src/Postmark/PostmarkClientBase.php
@@ -8,7 +8,9 @@
 
 namespace Postmark;
 
-use Postmark\Models\PostmarkException as PostmarkException;
+use GuzzleHttp\Client;
+use GuzzleHttp\RequestOptions;
+use Postmark\Models\PostmarkException;
 
 /**
  * This is the core class that interacts with the Postmark API. All clients should
@@ -26,7 +28,7 @@ abstract class PostmarkClientBase {
 	public static $BASE_URL = "https://api.postmarkapp.com";
 
 	/**
-	* VERIFY_SSL is defaulted to "true". 
+	* VERIFY_SSL is defaulted to "true".
 	*
 	* In some PHP configurations, SSL/TLS certificates cannot be verified.
 	* Rather than disabling SSL/TLS entirely in these circumstances, you may
@@ -35,7 +37,7 @@ abstract class PostmarkClientBase {
 	* but the risk is that if your connection has been compromised, your application could
 	* be subject to a Man-in-the-middle attack. However, this is still a better outcome
 	* than using no encryption at all.
-	* 
+	*
 	* If possible, you should try to resolve your PHP install's certificate issues as outline here:
 	* https://github.com/wildbit/postmark-php/wiki/SSL%20Errors%20on%20Windows
 	*/
@@ -47,12 +49,49 @@ abstract class PostmarkClientBase {
 	protected $os = NULL;
 	protected $timeout = 30;
 
+	/** @var  Client */
+	protected $client;
+
 	protected function __construct($token, $header, $timeout = 30) {
 		$this->authorization_header = $header;
 		$this->authorization_token = $token;
 		$this->version = phpversion();
 		$this->os = PHP_OS;
 		$this->timeout = $timeout;
+	}
+
+
+	/**
+	 * Return the injected GuzzleHttp\Client or create a default instance
+	 * @return Client
+	 */
+	protected function getClient() {
+
+		if(!$this->client) {
+			$this->client = new Client([
+				'base_uri' => self::$BASE_URL,
+				RequestOptions::VERIFY  => self::$VERIFY_SSL,
+				RequestOptions::TIMEOUT => $this->timeout,
+			]);
+		}
+		return $this->client;
+	}
+
+	/**
+	 * Provide a custom GuzzleHttp\Client to be used for HTTP requests
+	 *
+	 * @see http://docs.guzzlephp.org/en/latest/ for a full list of configuration options
+	 *
+	 * The following options will be ignored:
+	 * - http_errors
+	 * - headers
+	 * - query
+	 * - json
+	 *
+	 * @param Client $client
+	 */
+	public function setClient(Client $client) {
+		$this->client = $client;
 	}
 
 	/**
@@ -62,52 +101,44 @@ abstract class PostmarkClientBase {
 	 * @param string $path The API path.
 	 * @param array $body The content to be used (either as the query, or the json post/put body)
 	 * @return object
+	 *
+	 * @throws PostmarkException
 	 */
-	protected function processRestRequest($method = NULL, $path = NULL, $body = NULL) {
-		$client = new \GuzzleHttp\Client([
-			'exceptions' => false,
-			'timeout' => $this->timeout,
-        ]);
+	protected function processRestRequest($method = NULL, $path = NULL, array $body = []) {
+		$client = $this->getClient();
 
-		$url = PostmarkClientBase::$BASE_URL . $path;
+		$options = [
+			RequestOptions::HTTP_ERRORS => false,
+			RequestOptions::HEADERS => [
+				'User-Agent' => "Postmark-PHP (PHP Version:{$this->version}, OS:{$this->os})",
+				'Accept' => 'application/json',
+				'Content-Type' => 'application/json',
+				$this->authorization_header => $this->authorization_token
+			],
+		];
 
-		$options = array();
+		if(!empty($body)) {
 
-		if ($body != NULL) {
-			$cleanParams = array();
-
-			foreach ($body as $key => $value) {
-				if ($value !== NULL) {
-					$cleanParams[$key] = $value;
-				}
-			}
+			$cleanParams = array_filter($body, function($value) {
+				return $value !== null;
+			});
 
 			switch ($method) {
 				case 'GET':
 				case 'HEAD':
 				case 'DELETE':
 				case 'OPTIONS':
-					$options['query'] = $cleanParams;
+					$options[RequestOptions::QUERY] = $cleanParams;
 					break;
 				case 'PUT':
 				case 'POST':
 				case 'PATCH':
-					$options['json'] = $cleanParams;
+					$options[RequestOptions::JSON] = $cleanParams;
 					break;
 			}
 		}
 
-		$v = $this->version;
-		$o = $this->os;
-
-		$options['headers'] = array('User-Agent' => "Postmark-PHP (PHP Version:$v, OS:$o)",
-					 'Accept' => 'application/json',
-					 'Content-Type' => 'application/json',
-					 $this->authorization_header => $this->authorization_token);
-
-		$options['verify'] = PostmarkClientBase::$VERIFY_SSL;
-
-		$response = $client->request($method, $url, $options);
+		$response = $client->request($method, $path, $options);
 
 		$result = NULL;
 
@@ -146,5 +177,3 @@ abstract class PostmarkClientBase {
 		return $result;
 	}
 }
-
-?>


### PR DESCRIPTION
This allows the guzzle client to be injected so users can alter the default options. A default client is produced otherwise. This would allow the removal of $timeout, $BASE_URL and $VERIFY_SSL from the API in the future.  The request option strings were replaced with the Guzzle request option constants.