### PR TITLE
Removing unused $key variable in foreach

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -132,7 +132,7 @@ class PostmarkClient extends PostmarkClientBase {
 
 		$final = array();
 
-		foreach ($emailBatch as $key => $email) {
+		foreach ($emailBatch as $email) {
 			foreach ($email as $emailIdx => $emailValue) {
 				if (strtolower($emailIdx) == 'headers') {
 					$email[$emailIdx] = $this->fixHeaders($emailValue);


### PR DESCRIPTION
foreach has a $key in function sendEmailBatch but is unused. I removed it.
The functionality is exactly the same. 