### PR TITLE
Adding fromBase64EncodedData function

### DIFF
--- a/src/Postmark/Models/PostmarkAttachment.php
+++ b/src/Postmark/Models/PostmarkAttachment.php
@@ -11,7 +11,10 @@ class PostmarkAttachment implements \JsonSerializable {
 	public static function fromRawData($data, $attachmentName, $mimeType = NULL) {
 		return new PostmarkAttachment(base64_encode($data), $attachmentName, $mimeType);
 	}
-
+	
+	public static function fromBase64EncodedData($base64EncodedData, $attachmentName, $mimeType = NULL) {
+		return new PostmarkAttachment($base64EncodedData, $attachmentName, $mimeType);
+	}
 	/*
 	public static function fromStream($stream, $attachmentName, $mimeType = NULL) {
 	return new PostmarkAttachment($stream, $attachmentName, $mimeType);


### PR DESCRIPTION
Adding fromBase64EncodedData function. 
If you already have base64Encoded data, it seems strange to have to base64_decode and then letting postmark base64_encode it again...