### PR TITLE
processRestRequest should always return an array

### DIFF
--- a/src/Postmark/PostmarkClientBase.php
+++ b/src/Postmark/PostmarkClientBase.php
@@ -140,12 +140,10 @@ abstract class PostmarkClientBase {
 
 		$response = $client->request($method, $path, $options);
 
-		$result = NULL;
-
 		switch ($response->getStatusCode()) {
 			case 200:
-				$result = json_decode($response->getBody(), true);
-				break;
+				return json_decode($response->getBody(), true);
+				
 			case 401:
 
 				$ex = new PostmarkException();
@@ -153,18 +151,7 @@ abstract class PostmarkClientBase {
 				'Please verify that you used the correct token when you constructed your client.';
 				$ex->httpStatusCode = 401;
 				throw $ex;
-				break;
-			case 422:
-				$ex = new PostmarkException();
-
-				$body = json_decode($response->getBody(), true);
-
-				$ex->httpStatusCode = 422;
-				$ex->postmarkApiErrorCode = $body['ErrorCode'];
-				$ex->message = $body['Message'];
-
-				throw $ex;
-				break;
+				
 			case 500:
 				$ex = new PostmarkException();
 				$ex->httpStatusCode = 500;
@@ -172,8 +159,20 @@ abstract class PostmarkClientBase {
 				'In most cases the message is lost during the process, ' .
 				'and Postmark is notified so that we can investigate the issue.';
 				throw $ex;
-				break;
+			
+			case 422:
+			default: //any other status code
+				$ex = new PostmarkException();
+
+				$body = json_decode($response->getBody(), true);
+
+				$ex->httpStatusCode = $response->getStatusCode();
+				$ex->postmarkApiErrorCode = $body['ErrorCode'];
+				$ex->message = $body['Message'];
+
+				throw $ex;
+				
 		}
-		return $result;
+		
 	}
 }


### PR DESCRIPTION
processRestRequest should always return an array or throw an exception. 
I had an issue where postmark returned a status code that was not in the list, this made processRestRequest return ***NULL***. 
According to the documentation at the top of the function, this is not supposed to happen. 

And that is not something the DynamicResponseModel expects. 
The DynamicResponseModel __construct ***requires*** an array as parameter. 

To avoid these issues, the processRestRequest should throw an Exception if it receives a status code that is not 200. I've modified the code so it now includes a **default:** statement to catch all status codes we haven't defined. I've used the Exception handling of status code 422 to do this because this looks like a generic one. 

I've also removed the break; statements. There is no execution of code after a return or a throw statement. 
And finaly, since we are not using the variable $result, we can remove that one.