### PR TITLE
Support for sending email batches with templates

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -167,6 +167,32 @@ class PostmarkClient extends PostmarkClientBase {
 	}
 
 	/**
+	 * Send multiple emails with a template as a batch
+	 *
+	 * Each email is an associative array of values. See sendEmailWithTemplate()
+	 * for details on required values.
+	 *
+	 * @param array $emailBatch An array of emails to be sent in one batch.
+	 *
+	 * @return DynamicResponseModel
+	 * @throws Models\PostmarkException
+	 */
+	function sendEmailBatchWithTemplate($emailBatch = array()) {
+		$final = array();
+
+		foreach ($emailBatch as $email) {
+			foreach ($email as $emailIdx => $emailValue) {
+				if (strtolower($emailIdx) === 'headers') {
+					$email[$emailIdx] = $this->fixHeaders($emailValue);
+				}
+			}
+			$final[] = $email;
+		}
+
+		return new DynamicResponseModel($this->processRestRequest('POST', '/email/batchWithTemplates', array('Messages' => $final)));
+	}
+
+	/**
 	 * Get an overview of the delivery statistics for all email that has been sent through this Server.
 	 *
 	 * @return DynamicResponseModel


### PR DESCRIPTION
This pull requests enables support for sending email batches using templates on the `/email/batchWithTemplates` API endpoint. It adds a `sendEmailBatchWithTemplate` method to the `PostmarkClient` class.

See Postmark API Docs: [Send batch with templates](https://postmarkapp.com/developer/api/templates-api#send-batch-with-templates).

Implements feature requested in #51.