### PR TITLE
Task/add message stream to sending api

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -40,11 +40,12 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  array $attachments  An array of PostmarkAttachment objects.
 	 * @param  string $trackLinks  Can be any of "None", "HtmlAndText", "HtmlOnly", "TextOnly" to enable link tracking.
 	 * @param  array $metadata  Add metadata to the message. The metadata is an associative array, and values will be evaluated as strings by Postmark.
+	 * @param  array $messageStream  The message stream used to send this message. If not provided, the default transactional stream "outbound" will be used.
 	 * @return DynamicResponseModel
 	 */
 	function sendEmail($from, $to, $subject, $htmlBody = NULL, $textBody = NULL,
 		$tag = NULL, $trackOpens = true, $replyTo = NULL, $cc = NULL, $bcc = NULL,
-		$headers = NULL, $attachments = NULL, $trackLinks = NULL, $metadata = NULL) {
+		$headers = NULL, $attachments = NULL, $trackLinks = NULL, $metadata = NULL, $messageStream = NULL) {
 
 		$body = array();
 		$body['From'] = $from;
@@ -60,6 +61,7 @@ class PostmarkClient extends PostmarkClientBase {
 		$body['TrackOpens'] = $trackOpens;
 		$body['Attachments'] = $attachments;
 		$body['Metadata'] = $metadata;
+		$body['MessageStream'] = $messageStream;
 
 		// Since this parameter can override a per-server setting
 		// we have to check whether it was actually set.
@@ -88,12 +90,13 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  array $attachments  An array of PostmarkAttachment objects.
 	 * @param  string $trackLinks  Can be any of "None", "HtmlAndText", "HtmlOnly", "TextOnly" to enable link tracking.
 	 * @param  array $metadata  Add metadata to the message. The metadata is an associative array , and values will be evaluated as strings by Postmark.
+	 * @param  array $messageStream  The message stream used to send this message. If not provided, the default transactional stream "outbound" will be used.
 	 * @return DynamicResponseModel
 	 */
 	function sendEmailWithTemplate($from, $to, $templateIdOrAlias, $templateModel, $inlineCss = true,
 		$tag = NULL, $trackOpens = true, $replyTo = NULL,
 		$cc = NULL, $bcc = NULL, $headers = NULL, $attachments = NULL,
-		$trackLinks = NULL, $metadata = NULL) {
+		$trackLinks = NULL, $metadata = NULL, $messageStream = NULL) {
 
 		$body = array();
 		$body['From'] = $from;
@@ -108,6 +111,7 @@ class PostmarkClient extends PostmarkClientBase {
 		$body['TemplateModel'] = $templateModel;
 		$body['InlineCss'] = $inlineCss;
 		$body['Metadata'] = $metadata;
+		$body['MessageStream'] = $messageStream;
 
 
 		// Since this parameter can override a per-server setting

--- a/tests/PostmarkClientEmailTest.php
+++ b/tests/PostmarkClientEmailTest.php
@@ -49,13 +49,17 @@ class PostmarkClientEmailTest extends PostmarkClientBaseTest {
 		$this->assertNotEmpty($response, 'The client could not send message to the default stream.');
 		
 		// Sending with an invalid stream
-		$this->expectException(PostmarkException::class);
-		$client->sendEmail($tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
-			$tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
-			"Hello from the PHP Postmark Client Tests! ($currentTime)",
-			'<b>Hi there!</b>',
-			'This is a text body for a test email.', NULL, true, NULL, NULL, NULL,
-			NULL, NULL, NULL, NULL, 'unknown-stream');
+		try {
+			$response = $client->sendEmail($tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
+				$tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
+				"Hello from the PHP Postmark Client Tests! ($currentTime)",
+				'<b>Hi there!</b>',
+				'This is a text body for a test email.', NULL, true, NULL, NULL, NULL,
+				NULL, NULL, NULL, NULL, 'unknown-stream');
+		} catch(PostmarkException $ex){
+			$this->assertEquals(422, $ex->httpStatusCode);
+			$this->assertEquals("The 'MessageStream' provided does not exist on this server.", $ex->message);
+		}
 	}
 
 	function testClientCanSendMessageWithRawAttachment() {

--- a/tests/PostmarkClientEmailTest.php
+++ b/tests/PostmarkClientEmailTest.php
@@ -49,17 +49,13 @@ class PostmarkClientEmailTest extends PostmarkClientBaseTest {
 		$this->assertNotEmpty($response, 'The client could not send message to the default stream.');
 		
 		// Sending with an invalid stream
-		try {
-			$response = $client->sendEmail($tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
-				$tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
-				"Hello from the PHP Postmark Client Tests! ($currentTime)",
-				'<b>Hi there!</b>',
-				'This is a text body for a test email.', NULL, true, NULL, NULL, NULL,
-				NULL, NULL, NULL, NULL, 'unknown-stream');
-		} catch(PostmarkException $ex){
-			$this->assertEquals(422, $ex->httpStatusCode)
-			$this->assertEquals("The 'MessageStream' provided does not exist on this server.", $ex->message)
-		}
+		$this->expectException(PostmarkException::class);
+		$client->sendEmail($tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
+			$tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
+			"Hello from the PHP Postmark Client Tests! ($currentTime)",
+			'<b>Hi there!</b>',
+			'This is a text body for a test email.', NULL, true, NULL, NULL, NULL,
+			NULL, NULL, NULL, NULL, 'unknown-stream');
 	}
 
 	function testClientCanSendMessageWithRawAttachment() {

--- a/tests/PostmarkClientEmailTest.php
+++ b/tests/PostmarkClientEmailTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use Postmark\Models\PostmarkAttachment;
+use Postmark\Models\PostmarkException;
 use Postmark\PostmarkClient;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
@@ -29,6 +30,36 @@ class PostmarkClientEmailTest extends PostmarkClientBaseTest {
 			'<b>Hi there!</b>',
 			'This is a text body for a test email.');
 		$this->assertNotEmpty($response, 'The client could not send a basic message.');
+	}
+
+	function testClientCanSetMessageStream() {
+		$tk = parent::$testKeys;
+
+		$client = new PostmarkClient($tk->WRITE_TEST_SERVER_TOKEN, $tk->TEST_TIMEOUT);
+
+		$currentTime = date("c");
+		
+		//Sending with a valid stream
+		$response = $client->sendEmail($tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
+			$tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
+			"Hello from the PHP Postmark Client Tests! ($currentTime)",
+			'<b>Hi there!</b>',
+			'This is a text body for a test email via the default stream.', NULL, true, NULL, NULL, NULL,
+			NULL, NULL, NULL, NULL, 'outbound');
+		$this->assertNotEmpty($response, 'The client could not send message to the default stream.');
+		
+		// Sending with an invalid stream
+		try {
+			$response = $client->sendEmail($tk->WRITE_TEST_SENDER_EMAIL_ADDRESS,
+				$tk->WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
+				"Hello from the PHP Postmark Client Tests! ($currentTime)",
+				'<b>Hi there!</b>',
+				'This is a text body for a test email.', NULL, true, NULL, NULL, NULL,
+				NULL, NULL, NULL, NULL, 'unknown-stream');
+		} catch(PostmarkException $ex){
+			$this->assertEquals(422, $ex->httpStatusCode)
+			$this->assertEquals("The 'MessageStream' provided does not exist on this server.", $ex->message)
+		}
 	}
 
 	function testClientCanSendMessageWithRawAttachment() {


### PR DESCRIPTION
- Adds `MessageStream` field to the email sending methods
- `MessageStream` API will be added in a subsequent PR (after enabling it globally)