### PR TITLE
Support int64 bounce IDs

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -248,6 +248,9 @@ class PostmarkClient extends PostmarkClientBase {
 	 * Locate information on a specific email bounce.
 	 *
 	 * @param  integer $id The ID of the bounce to get.
+	 *
+	 * If the $id value is greater than PHP_INT_MAX, the ID can be passed as a string.
+	 *
 	 * @return DynamicResponseModel
 	 */
 	function getBounce($id) {
@@ -258,6 +261,9 @@ class PostmarkClient extends PostmarkClientBase {
 	 * Get a "dump" for a specific bounce.
 	 *
 	 * @param  integer $id The ID of the bounce for which we want a dump.
+	 *
+	 * If the $id value is greater than PHP_INT_MAX, the ID can be passed as a string.
+	 *
 	 * @return string
 	 */
 	function getBounceDump($id) {
@@ -268,6 +274,9 @@ class PostmarkClient extends PostmarkClientBase {
 	 * Cause the email address associated with a Bounce to be reactivated.
 	 *
 	 * @param  integer $id The bounce which has a deactivated email address.
+	 *
+	 * If the $id value is greater than PHP_INT_MAX, the ID can be passed as a string.
+	 *
 	 * @return DynamicResponseModel
 	 */
 	function activateBounce($id) {

--- a/src/Postmark/PostmarkClientBase.php
+++ b/src/Postmark/PostmarkClientBase.php
@@ -140,7 +140,8 @@ abstract class PostmarkClientBase {
 
 		switch ($response->getStatusCode()) {
 			case 200:
-				return json_decode($response->getBody(), true);
+				// Casting BIGINT as STRING instead of the default FLOAT, to avoid loss of precision.
+				return json_decode($response->getBody(), true, 512, JSON_BIGINT_AS_STRING);
 			case 401:
 				$ex = new PostmarkException();
 				$ex->message = 'Unauthorized: Missing or incorrect API token in header. ' .


### PR DESCRIPTION
Integers in `PHP` are either 32-bit or 64-bit based on the underlying architecture.

If it's a 32-bit platform OR if it's a Windows platform with a `PHP` version prior to `PHP 7`, then 64-bit ints are not supported. This limit is defined by the `PHP_MAX_INT` constant.

Integer overflow treats `BIGINTs` as `floats`, so there can be loss of precision and we cannot reliably guarantee the use of `float` IDs.

Fortunately for us, we don't do any arithmetic operations with those IDs, so if they get too big, we can treat them as strings when we form the `URL`.