### PR TITLE
Don't enable Open-tracking by default in sending endpoints

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -44,7 +44,7 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @return DynamicResponseModel
 	 */
 	function sendEmail($from, $to, $subject, $htmlBody = NULL, $textBody = NULL,
-		$tag = NULL, $trackOpens = true, $replyTo = NULL, $cc = NULL, $bcc = NULL,
+		$tag = NULL, $trackOpens = NULL, $replyTo = NULL, $cc = NULL, $bcc = NULL,
 		$headers = NULL, $attachments = NULL, $trackLinks = NULL, $metadata = NULL, $messageStream = NULL) {
 
 		$body = array();
@@ -94,7 +94,7 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @return DynamicResponseModel
 	 */
 	function sendEmailWithTemplate($from, $to, $templateIdOrAlias, $templateModel, $inlineCss = true,
-		$tag = NULL, $trackOpens = true, $replyTo = NULL,
+		$tag = NULL, $trackOpens = NULL, $replyTo = NULL,
 		$cc = NULL, $bcc = NULL, $headers = NULL, $attachments = NULL,
 		$trackLinks = NULL, $metadata = NULL, $messageStream = NULL) {
 


### PR DESCRIPTION
@pgraham3 Not sure what were the historical reasons for this being enabled by default, but users can unknowingly send emails with open-tracking enabled and be flagged by `Hey.com`.

This PR changes the default for this setting to be the stream-level setting for open-tracking, which is in line with what other public libraries or our API is doing.