### PR TITLE
Adding possibility to filter on messagestream for different endpoints

### DIFF
--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -224,11 +224,12 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $messageID Filter by MessageID
 	 * @param  string $fromdate Filter for bounces after is date.
 	 * @param  string $todate Filter for bounces before this date.
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
 	function getBounces($count = 100, $offset = 0, $type = NULL,
 		$inactive = NULL, $emailFilter = NULL, $tag = NULL, $messageID = NULL,
-	        $fromdate = NULL, $todate = NULL) {
+	        $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 
 		$query = array();
 		$query['type'] = $type;
@@ -240,6 +241,7 @@ class PostmarkClient extends PostmarkClientBase {
 		$query['offset'] = $offset;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/bounces', $query));
 	}
@@ -351,11 +353,12 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $fromdate Filter to messages on or after YYYY-MM-DD
 	 * @param  string $todate Filter to messages on or before YYYY-MM-DD
 	 * @param  string $metadata An associatative array of key-values that must all match values included in the metadata of matching sent messages.
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
 	function getOutboundMessages($count = 100, $offset = 0, $recipient = NULL,
 		$fromEmail = NULL, $tag = NULL, $subject = NULL, $status = NULL,
-		$fromdate = NULL, $todate = NULL, $metadata = NULL) {
+		$fromdate = NULL, $todate = NULL, $metadata = NULL, $messagestream = NULL) {
 
 		$query = array();
 		$query["recipient"] = $recipient;
@@ -367,6 +370,7 @@ class PostmarkClient extends PostmarkClientBase {
 		$query["status"] = $status;
 		$query["fromdate"] = $fromdate;
 		$query["todate"] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		if($metadata != NULL) {
 			foreach($metadata as $key => $value) {
@@ -479,12 +483,13 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $country Filter by Country.
 	 * @param  string $region Filter by Region.
 	 * @param  string $city Filter by City.
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
 	function getOpenStatistics($count = 100, $offset = 0, $recipient = NULL,
 		$tag = NULL, $clientName = NULL, $clientCompany = NULL, $clientFamily = NULL,
 		$osName = NULL, $osFamily = NULL, $osCompany = NULL, $platform = NULL,
-		$country = NULL, $region = NULL, $city = NULL) {
+		$country = NULL, $region = NULL, $city = NULL, $messagestream = NULL) {
 
 		$query = array();
 		$query['count'] = $count;
@@ -501,6 +506,7 @@ class PostmarkClient extends PostmarkClientBase {
 		$query['country'] = $country;
 		$query['region'] = $region;
 		$query['city'] = $city;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/messages/outbound/opens', $query));
 	}
@@ -522,12 +528,13 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $country Filter by Country.
 	 * @param  string $region Filter by Region.
 	 * @param  string $city Filter by City.
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
 	function getClickStatistics($count = 100, $offset = 0, $recipient = NULL,
 		$tag = NULL, $clientName = NULL, $clientCompany = NULL, $clientFamily = NULL,
 		$osName = NULL, $osFamily = NULL, $osCompany = NULL, $platform = NULL,
-		$country = NULL, $region = NULL, $city = NULL) {
+		$country = NULL, $region = NULL, $city = NULL, $messagestream = NULL) {
 
 		$query = array();
 		$query['count'] = $count;
@@ -544,6 +551,7 @@ class PostmarkClient extends PostmarkClientBase {
 		$query['country'] = $country;
 		$query['region'] = $region;
 		$query['city'] = $city;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/messages/outbound/clicks', $query));
 	}
@@ -589,14 +597,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundOverviewStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundOverviewStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound', $query));
 	}
@@ -608,14 +618,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundSendStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundSendStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/sends', $query));
 	}
@@ -627,14 +639,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundBounceStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundBounceStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/bounces', $query));
 	}
@@ -646,14 +660,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundSpamComplaintStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundSpamComplaintStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/spam', $query));
 	}
@@ -665,14 +681,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundTrackedStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundTrackedStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/tracked', $query));
 	}
@@ -684,14 +702,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundOpenStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundOpenStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/opens', $query));
 	}
@@ -703,14 +723,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundPlatformStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundPlatformStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/opens/platforms', $query));
 	}
@@ -722,14 +744,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundEmailClientStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundEmailClientStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/opens/emailclients', $query));
 	}
@@ -760,14 +784,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundClickStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundClickStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/clicks', $query));
 	}
@@ -779,14 +805,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundClickBrowserFamilyStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundClickBrowserFamilyStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/clicks/browserfamilies', $query));
 	}
@@ -799,14 +827,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundClickBrowserPlatformStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundClickBrowserPlatformStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/clicks/platforms', $query));
 	}
@@ -819,14 +849,16 @@ class PostmarkClient extends PostmarkClientBase {
 	 * @param  string $tag Filter by tag.
 	 * @param  string $fromdate  must be of the format 'YYYY-MM-DD'
 	 * @param  string $todate  must be of the format 'YYYY-MM-DD'
+	 * @param  string $messagestream Filter by Message Stream ID. If null default "outbound" transactional stream.
 	 * @return DynamicResponseModel
 	 */
-	function getOutboundClickLocationStatistics($tag = NULL, $fromdate = NULL, $todate = NULL) {
+	function getOutboundClickLocationStatistics($tag = NULL, $fromdate = NULL, $todate = NULL, $messagestream = NULL) {
 		$query = array();
 
 		$query['tag'] = $tag;
 		$query['fromdate'] = $fromdate;
 		$query['todate'] = $todate;
+		$query['messagestream'] = $messagestream;
 
 		return new DynamicResponseModel($this->processRestRequest('GET', '/stats/outbound/clicks/location', $query));
 	}


### PR DESCRIPTION
Currently, multiple endpoints support to filter on Message Stream. Because the fallback (if not provided) is the default "outbound" stream, it is not possible to filter only one stream. This PR fixes this issue.