### PR TITLE
Adds PHP 8.0 and 8.1 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,12 @@ workflows:
           version: "7.4"
           requires:
             - php73
+      - unit-tests:
+          name: php80
+          version: "8.0"
+      - unit-tests:
+          name: php81
+          version: "8.1"
 
 jobs:
   unit-tests:


### PR DESCRIPTION
Updates Circle CI configuration to run on 8.0 and 8.1 which *should* fail.