### PR TITLE
Temporarily suppress 8.1 warnings to maintain backward compatibility.

### DIFF
--- a/src/Postmark/Models/CaseInsensitiveArray.php
+++ b/src/Postmark/Models/CaseInsensitiveArray.php
@@ -24,6 +24,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Iterator {
 		$this->_container = array_change_key_case($initialArray);
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value) {
 		if (is_string($offset)) {
 			$offset = $this->fixOffsetName($offset);
@@ -45,6 +46,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Iterator {
 		return isset($this->_container[$offset]);
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset) {
 		if (is_string($offset)) {
 			$offset = $this->fixOffsetName($offset);
@@ -62,25 +64,30 @@ class CaseInsensitiveArray implements \ArrayAccess, \Iterator {
 		$this->_container[$offset] : null;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function current() {
 		// use "offsetGet" instead of indexes
 		// so that subclasses can override behavior if needed.
 		return $this->offsetGet($this->key());
 	}
 
+	#[\ReturnTypeWillChange]
 	public function key() {
         $keys = array_keys($this->_container);
 		return $keys[$this->_pointer];
 	}
 
+	#[\ReturnTypeWillChange]
 	public function next() {
 		$this->_pointer++;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function rewind() {
 		$this->_pointer = 0;
 	}
 
+	#[\ReturnTypeWillChange]
 	public function valid() {
 		return count(array_keys($this->_container)) > $this->_pointer;
 	}

--- a/src/Postmark/Models/CaseInsensitiveArray.php
+++ b/src/Postmark/Models/CaseInsensitiveArray.php
@@ -36,6 +36,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Iterator {
 		}
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset) {
 		if (is_string($offset)) {
 			$offset = $this->fixOffsetName($offset);
@@ -52,6 +53,7 @@ class CaseInsensitiveArray implements \ArrayAccess, \Iterator {
 		unset($this->_container[$offset]);
 	}
 
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset) {
 		if (is_string($offset)) {
 			$offset = $this->fixOffsetName($offset);

--- a/src/Postmark/Models/DynamicResponseModel.php
+++ b/src/Postmark/Models/DynamicResponseModel.php
@@ -53,6 +53,7 @@ class DynamicResponseModel extends CaseInsensitiveArray {
 	/**
 	 * Infrastructure. Allows indexer to return a DynamicResponseModel.
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset) {
 		$result = parent::offsetGet($offset);
 		if ($result != NULL && is_array($result)) {

--- a/src/Postmark/Models/PostmarkAttachment.php
+++ b/src/Postmark/Models/PostmarkAttachment.php
@@ -21,6 +21,7 @@ class PostmarkAttachment implements \JsonSerializable {
 		return new PostmarkAttachment(base64_encode(file_get_contents($filePath)), $attachmentName, $mimeType, $contentId);
 	}
 
+	#[\ReturnTypeWillChange]
 	function jsonSerialize() {
 
 		$retval = array(


### PR DESCRIPTION
https://github.com/wildbit/postmark-php/issues/88